### PR TITLE
Add Seminole State College disclaimer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,14 +9,16 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.2.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.23.10)
+    commonmarker (0.23.11)
     concurrent-ruby (1.3.4)
-    dnsruby (1.70.0)
+    dnsruby (1.72.3)
+      base64 (~> 0.2.0)
       simpleidn (~> 0.2.1)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
@@ -24,12 +26,23 @@ GEM
     ethon (0.16.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
-    execjs (2.9.1)
-    faraday (2.9.0)
-      faraday-net_http (>= 2.0, < 3.2)
-    faraday-net_http (3.1.0)
-      net-http
+    execjs (2.10.0)
+    faraday (2.12.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-aarch64-linux-musl)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm-linux-musl)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86-linux-musl)
+    ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (228)
@@ -197,6 +210,7 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
+    json (2.9.0)
     kramdown (2.3.2)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -205,15 +219,26 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.2)
     mercenary (0.3.6)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.22.2)
-    net-http (0.4.1)
+    minitest (5.25.4)
+    net-http (0.6.0)
       uri
-    nokogiri (1.16.2-x86_64-linux)
+    nokogiri (1.17.0-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.17.0-arm-linux)
+      racc (~> 1.4)
+    nokogiri (1.17.0-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.17.0-x86-linux)
+      racc (~> 1.4)
+    nokogiri (1.17.0-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.17.0-x86_64-linux)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -221,7 +246,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.7)
-    racc (1.7.3)
+    racc (1.8.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
@@ -237,8 +262,7 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    simpleidn (0.2.1)
-      unf (~> 0.1.4)
+    simpleidn (0.2.3)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
@@ -246,19 +270,29 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2024.1)
+    tzinfo-data (1.2024.2)
       tzinfo (>= 1.0.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.9.1)
     unicode-display_width (1.8.0)
-    uri (0.13.0)
+    uri (1.0.2)
     wdm (0.1.1)
-    webrick (1.8.1)
-    zeitwerk (2.6.13)
+    webrick (1.9.1)
+    zeitwerk (2.7.1)
 
 PLATFORMS
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86-linux
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
   x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   github-pages (~> 228)
@@ -270,4 +304,4 @@ DEPENDENCIES
   webrick (~> 1.8)
 
 BUNDLED WITH
-   2.4.22
+   2.5.23

--- a/index.md
+++ b/index.md
@@ -19,7 +19,7 @@ nav_order: 1
 <p />
 
 Orlando Code Camp is organized by the [Orlando .NET User Group (ONETUG)](https://onetug.net)
-and hosted at the Sanford/Lake Mary campus of [Seminole State College](https://www.seminolestate.edu/slm).
+and hosted at the Sanford/Lake Mary campus of [Seminole State College](#disclaimer).
 
 <p />
 
@@ -72,3 +72,7 @@ Orlando Code Camp proudly partners with the following local organizations:
   ![Google Developer Group (GDG) Central Florida](/assets/img/partners/GDG-Central-Florida.png "Google Developer Group (GDG) Central Florida"){:class="logo-home-page-short-wide"}
   ![SQLOrlando](/assets/img/partners/SQLOrlando.jpg "SQLOrlando"){:class="logo-home-page-wide"}
 </span>
+
+---
+ <h3 id=disclaimer>Disclaimer</h3>
+ <p><em>This event and its organizer are neither affiliated with nor endorsed by <a href="https://www.seminolestate.edu/slm" target="_blank">Seminole State College</a> of Florida. Any views expressed at this event are solely those of the person expressing them and not those of Seminole State College of Florida.</em></p>

--- a/location.md
+++ b/location.md
@@ -16,21 +16,26 @@ Orlando Code Camp 2025 will be held on April 5th 2025 at Seminole State College 
 
 ## Event Address
 
-Wayne M. Densch Partnership Center
-Seminole State College - Sanford/Lake Mary Campus
-100 Weldon Blvd, Sanford FL 32773
+<p>
+  <strong>Seminole State College - Sanford/Lake Mary Campus</strong><br/>
+  <a href="https://maps.google.com/?q=Wayne+M.+Densch+Partnership+Center,+Seminole+State+College,+100+Weldon+Blvd,+Sanford+FL+32773" target="_blank">
+    Wayne M. Densch Partnership Center<br />
+    100 Weldon Blvd<br/>
+    Sanford FL, 32773
+  </a>
+</p>
+
+<!-- [Google Maps (external)](https://maps.app.goo.gl/Y85J2V6d3RyRTnPe7){:target="_blank"} -->
+
+<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1749.0897107327119!2d-81.30701413734684!3d28.744059558742478!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x88e76d180ab1b97b%3A0xd7369878036400a1!2sWayne%20M.%20Densch%20Partnership%20Center!5e0!3m2!1sen!2sus!4v1663965771738!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+
+<a href="https://maps.seminolestate.edu/#!BLD_2016012779162" target="_blank">Campus map (external)</a>
 
 Note: there are 3 entrances to campus via
 
 + Wheldon Blvd
 + Broadmoor Rd
 + College Dr
-
-[Google Maps (external)](https://maps.app.goo.gl/Y85J2V6d3RyRTnPe7){:target="_blank"}
-
-<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1749.0897107327119!2d-81.30701413734684!3d28.744059558742478!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x88e76d180ab1b97b%3A0xd7369878036400a1!2sWayne%20M.%20Densch%20Partnership%20Center!5e0!3m2!1sen!2sus!4v1663965771738!5m2!1sen!2sus" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-
-[Campus map (external)](https://maps.seminolestate.edu/#!BLD_2016012779162)
 
 <a href="/assets/img/maps/Seminole State Landmarks - Full-Size.png" alt="Full Size Map of Event Landmarks at Seminole State" target="_blank">
   <img src="/assets/img/maps/Seminole State Landmarks - Thumbnail.png"  alt="Thumbnail Map of Event Landmarks at Seminole State" />
@@ -58,3 +63,7 @@ The Westin Lake Mary, Orlando North (10 minute drive)
 2974 International Parkway
 Lake Mary, Florida 32746
 +1 407-531-3555
+
+---
+<h3 id=disclaimer>Disclaimer</h3>
+ <p><em>This event and its organizer are neither affiliated with nor endorsed by <a href="https://www.seminolestate.edu/slm" target="_blank">Seminole State College</a> of Florida. Any views expressed at this event are solely those of the person expressing them and not those of Seminole State College of Florida.</em></p>


### PR DESCRIPTION
Add disclaimer for Seminole State College on home and location pages.
Also updated the location page with bolded event address and interactive Google Maps link

* Added `<strong>` tags to emphasize the event address for better visibility.
* Included a clickable Google Maps link to make the address accessible for navigation.

Also, Update Gemfile.lock with latest bundler