### PR TITLE
Add wide schedule

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,10 +59,10 @@ nav_external_links:
     permalink: /call-for-speakers/
     url: https://sessionize.com/orlando-code-camp-2025/
     hide_icon: true
-#   - title: Schedule (Sessionize)
-#     permalink: /schedule/
-#     url: https://sessionize.com/view/ht1oni9m/GridSmart?format=Embed_Styled_Html&isDark=False&title=Orlando%20Code%20Camp%202024
-#     hide_icon: true
+  # - title: Schedule (Sessionize)
+  #   permalink: /schedule-external/
+  #   url: https://sessionize.com/view/ht1oni9m/GridSmart?format=Embed_Styled_Html&isDark=False&title=Orlando%20Code%20Camp%202024
+  #   hide_icon: true
   # - title: Sign Up (Eventbrite)
   #   url: https://www.eventbrite.com/e/orlando-code-camp-2024-tickets-800584980227
   #   hide_icon: true

--- a/_layouts/full-width.html
+++ b/_layouts/full-width.html
@@ -1,0 +1,52 @@
+<html>
+{% include head.html %}
+<body class="no-headers-body">
+  <ul class="links-container">
+    {% assign sorted_pages = site.pages | sort: 'nav_order' %}
+
+    {% for page in sorted_pages %}
+    {% unless page.nav_exclude == true %}
+      {% if page.path contains '.md' %}
+          <li><a href="{{ page.url | relative_url }}">{{ page.title | default: page.url }}</a></li>
+      {% endif %}
+    {% endunless %}
+    {% endfor %}
+
+    {% for page in site.nav_external_links %}
+          <li><a href="{{ page.url }}">{{ page.title | default: page.url }}</a></li>
+    {% endfor %}
+  </ul>
+
+{{ content }}
+
+  {% if page.has_children == true and page.has_toc != false %}
+    {% include components/children_nav.html %}
+  {% endif %}
+
+  {% include components/footer.html %}
+
+  <style>
+    .no-headers-body {
+        padding: 5px 10px;
+    }
+
+    .links-container {
+        text-align: center;
+        list-style: none;
+        padding: 0;
+        display: flex;
+        flex-wrap: wrap; 
+        gap: 10px; 
+        justify-content: center;
+        margin-top: 15px;
+        font-size: 1.0em;
+    }
+
+    @media (min-width: 50rem) {
+        .links-container {
+            font-size: 1.3em;
+        }
+    }
+  </style>
+</body>
+</html>

--- a/schedule.md
+++ b/schedule.md
@@ -1,17 +1,23 @@
 ---
-layout: page
+layout: full-width
 title: Schedule
 permalink: /schedule/
-# nav_order: 6
+nav_order: 6
 nav_exclude: true
 ---
 
-{::comment}
-
 # Schedule
 
-<p />
+<iframe src="https://sessionize.com/view/ht1oni9m/GridSmart?format=Embed_Styled_Html&isDark=False&title=Orlando%20Code%20Camp%202025" 
+    id="sessionize-frame">
+</iframe>
 
-[See the full schedule here (Sessionize)](https://sessionize.com/view/ht1oni9m/GridSmart?format=Embed_Styled_Html&isDark=False&title=Orlando%20Code%20Camp%202024){:target="_blank"}
+[View schedule on Sessionize](https://sessionize.com/view/ht1oni9m/GridSmart?format=Embed_Styled_Html&isDark=False&title=Orlando%20Code%20Camp%202025){:target="_blank"}
 
-{:/comment}
+<style>
+    #sessionize-frame {
+        width: 100%;
+        height: 2000px;
+        border: none;
+    }
+</style>


### PR DESCRIPTION
Adding a custom "wide" layout that can be opted into by pages (currently only Schedule) that shows navigation links across the top only.

Mobile layout:

![image](https://github.com/user-attachments/assets/81657a85-a727-4171-a10c-3d8fd64ee241)


Desktop layout:

![image](https://github.com/user-attachments/assets/be0bd510-1e70-48b7-96c9-31b64eee6487)

Right now this page can only be manually navigated to via the `/schedule` path, as it isn't added to primary navigation.

Caveat: I have no idea if this will actually work well on mobile until I publish it!
