### PR TITLE
Adds the countdown timer to home page and location page

### DIFF
--- a/_includes/clock.html
+++ b/_includes/clock.html
@@ -1,4 +1,4 @@
-<div class="pt1 f2 sans-serif" id="clock-div">
+<div class="pt1 f3 sans-serif" id="clock-div">
   <div class="tc pa2 br3 dib clock-face">
     <div class="pa2 br3 dib">
       <span class="pa3 br3 dib digit" id="days">0</span>
@@ -19,4 +19,4 @@
   </div>
 </div>
 
-<script src="./assets/js/clock.js" charset="utf-8"></script>
+<script src="/assets/js/clock.js" charset="utf-8"></script>

--- a/assets/js/clock.js
+++ b/assets/js/clock.js
@@ -37,7 +37,7 @@ function initializeClock(id, endTick) {
 
   function updateClock() {
     var startTick = new Date().getTime();
-    var time = getTimeRemaining(startTick,endTick);
+    var time = getTimeRemaining(startTick, endTick);
 
     daysSpan.innerHTML = time.days;
     hoursSpan.innerHTML = ('0' + time.hours).slice(-2);

--- a/index.md
+++ b/index.md
@@ -8,11 +8,14 @@ nav_order: 1
 
 # Orlando Code Camp 2025 - April 5th 2025
 
+{:/comment}
+
 <div id="countdown-clock" style="text-align: center;">{% include clock.html %}</div>
 
+{::comment}
 ## Seminole State College, Sanford, FL
-
 {:/comment}
+
 
 ![Orlando Code Camp 2025 logo](/assets/img/banners/2025%20Code%20Camp%20-%20Banner.png "Orlando Code Camp 2025 - April 5th, 2025"){:class="banner-home-page"}
 

--- a/location.md
+++ b/location.md
@@ -8,9 +8,11 @@ has_toc: true
 
 {:toc}
 
-# Location
 
-<p />
+<div id="countdown-clock" style="text-align: center;">{% include clock.html %}</div>
+
+
+# Location
 
 Orlando Code Camp 2025 will be held on April 5th 2025 at Seminole State College in Sanford, FL.
 


### PR DESCRIPTION
I added the countdown timer to both the home page and the location page. Just a thought. @andylech If you don't like that, no problem. Just let me know and I'll remove it from the `/location` page. Here's some screen shots in both desktop and mobile for context:

![image](https://github.com/user-attachments/assets/b76ded8e-7a33-480c-8869-7aa6bb6b3652)

![image](https://github.com/user-attachments/assets/7c3274da-3f62-4e7e-85c9-07a90554c037)

<img width="1270" alt="image" src="https://github.com/user-attachments/assets/17912e34-a28b-4943-b1e4-1425ec4d39f0" />

<img width="1422" alt="image" src="https://github.com/user-attachments/assets/ed541f81-5ea0-494f-911f-56de6dc6ad2a" />
