### PR TITLE
Data-driven bookend events, sticky headers, scroll fixes, and CODE Magazine sponsor

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -79,8 +79,9 @@
   url: https://dynabytetech.com/en/
   sponsorType: Snack Sponsor
   description: "Dynabyte is a Swedish software solutions firm with offices in Stockholm and St. Petersburg, Florida, specializing in digital enterprise solutions through software development, cloud computing, data engineering, and AI. Their team delivers across sectors including financial services, insurance, and manufacturing, with clients like Spotify, Klarna, and Ikea."
-# - name: CODE Magazine
-#   logoPath: /assets/img/sponsors/CODE-Magazine/code-sponsor.png
-#   logoStyle: standard
-#   url: https://www.codemag.com/
-#   level: Swag
+- name: CODE Magazine
+  logoPath: /assets/img/sponsors/CODE-Magazine/code-sponsor.png
+  logoStyle: standard
+  url: https://www.codemag.com/
+  sponsorType: Swag Sponsor
+  description: "CODE Magazine is a leading independent publication for professional software developers, covering .NET, C#, JavaScript, AI, cloud development, and more. Published by EPS Software since 1998, CODE Magazine delivers in-depth technical articles and real-world guidance for the developer community."

--- a/_sass/redesign/_agenda.scss
+++ b/_sass/redesign/_agenda.scss
@@ -3,6 +3,21 @@
 // =============================================================================
 
 .agenda-page {
+  // Total sticky offset: header + nav pills + filter bar (set via JS ResizeObserver)
+  --sticky-offset: calc(
+    var(--header-height-mobile)
+    + var(--timeslot-nav-height, 49px)
+    + var(--filter-bar-height, 49px)
+  );
+
+  @include tablet-up {
+    --sticky-offset: calc(
+      var(--header-height)
+      + var(--timeslot-nav-height, 49px)
+      + var(--filter-bar-height, 49px)
+    );
+  }
+
   .main-content {
     padding-bottom: 0;
   }
@@ -125,6 +140,16 @@
   &.pill-bookend {
     border-style: dashed;
     font-family: var(--font-family-sans);
+  }
+}
+
+// Non-clickable bookend pills (rendered as <span>)
+span.timeslot-pill.pill-bookend {
+  cursor: default;
+
+  &:hover {
+    border-color: var(--color-border-default);
+    color: var(--color-text-secondary);
   }
 }
 
@@ -348,6 +373,102 @@
 }
 
 // ---------------------------------------------------------------------------
+// Break Notice — compact lunch / snack info strip
+// ---------------------------------------------------------------------------
+
+.break-notice {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  border: 1px dashed var(--color-border-default);
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg-secondary);
+  margin-bottom: var(--spacing-6);
+
+  @include tablet-up {
+    align-items: center;
+    padding: var(--spacing-4) var(--spacing-6);
+    border-color: var(--color-border-light);
+  }
+}
+
+.break-notice-divider {
+  width: 100%;
+  height: 1px;
+  background-color: var(--color-border-default);
+  flex-shrink: 0;
+
+  @include tablet-up {
+    width: 60%;
+    background-color: var(--color-border-light);
+  }
+}
+
+.break-notice-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  white-space: nowrap;
+  flex-shrink: 0;
+
+  @include tablet-up {
+    gap: var(--spacing-3);
+  }
+
+  @include mobile-only {
+    flex-wrap: wrap;
+  }
+}
+
+.break-notice-icon {
+  color: var(--color-text-muted);
+  display: flex;
+  flex-shrink: 0;
+
+  @include tablet-up {
+    color: var(--color-accent-primary);
+  }
+}
+
+.break-notice-title {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+
+  @include tablet-up {
+    font-size: var(--font-size-base);
+  }
+}
+
+.break-notice-time {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-accent-secondary);
+
+  @include tablet-up {
+    font-size: var(--font-size-base);
+  }
+}
+
+.break-notice-location {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+
+  @include tablet-up {
+    font-size: var(--font-size-sm);
+  }
+
+  &::before {
+    content: '·';
+    margin-right: var(--spacing-2);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Agenda Timeline
 // ---------------------------------------------------------------------------
 
@@ -466,7 +587,7 @@
 // ---------------------------------------------------------------------------
 
 .timeslot-block {
-  scroll-margin-top: 160px; // account for sticky header + nav
+  scroll-margin-top: calc(var(--sticky-offset) + 8px);
 }
 
 .timeslot-header {
@@ -476,6 +597,10 @@
   padding: var(--spacing-3) 0;
   border-bottom: 2px solid var(--color-accent-primary);
   margin-bottom: var(--spacing-4);
+  position: sticky;
+  top: var(--sticky-offset);
+  background-color: var(--color-bg-primary);
+  z-index: calc(var(--z-sticky, 1020) - 2);
 }
 
 .timeslot-header-unscheduled {

--- a/_sass/redesign/_agenda.scss
+++ b/_sass/redesign/_agenda.scss
@@ -6,15 +6,15 @@
   // Total sticky offset: header + nav pills + filter bar (set via JS ResizeObserver)
   --sticky-offset: calc(
     var(--header-height-mobile)
-    + var(--timeslot-nav-height, 49px)
-    + var(--filter-bar-height, 49px)
+    + var(--timeslot-nav-height, 0px)
+    + var(--filter-bar-height, 0px)
   );
 
   @include tablet-up {
     --sticky-offset: calc(
       var(--header-height)
-      + var(--timeslot-nav-height, 49px)
-      + var(--filter-bar-height, 49px)
+      + var(--timeslot-nav-height, 0px)
+      + var(--filter-bar-height, 0px)
     );
   }
 

--- a/_sass/redesign/_components.scss
+++ b/_sass/redesign/_components.scss
@@ -712,6 +712,7 @@
   color: #fed7aa;
 }
 
+
 .sponsor-feature-content {
   display: flex;
   flex-direction: column;

--- a/assets/js/agenda/app.js
+++ b/assets/js/agenda/app.js
@@ -5,6 +5,7 @@ import { useBookmarks, useAgendaBuilder } from './hooks.js';
 import {
   AgendaTimeline,
   AgendaBuilderPanel,
+  BreakNotice,
   FilterBar,
   TimeSlotNav,
   SessionModal,
@@ -281,6 +282,8 @@ function AgendaApp() {
     if (totalScheduledCount < sessionThreshold) return items;
 
     bookendEvents.forEach((evt, i) => {
+      // Skip bookend events that aren't visible on any surface
+      if (evt.show_in_nav === false && evt.show_in_body === false) return;
       const slotId = `bookend-${i}`;
       items.push({
         type: 'bookend',
@@ -346,17 +349,22 @@ function AgendaApp() {
     return () => { document.body.style.overflow = ''; };
   }, [modalSession, importExportMode]);
 
-  // Measure timeslot nav height and set CSS variable for filter bar offset
+  // Measure sticky element heights and set CSS variables for offsets
   useEffect(() => {
     const nav = document.querySelector('.timeslot-nav');
-    if (!nav) return;
-    const observer = new ResizeObserver(([entry]) => {
-      document.documentElement.style.setProperty(
-        '--timeslot-nav-height',
-        `${entry.borderBoxSize?.[0]?.blockSize ?? entry.target.offsetHeight}px`
-      );
+    const filterBar = document.querySelector('.filter-bar');
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const h = entry.borderBoxSize?.[0]?.blockSize ?? entry.target.offsetHeight;
+        if (entry.target === nav) {
+          document.documentElement.style.setProperty('--timeslot-nav-height', `${h}px`);
+        } else if (entry.target === filterBar) {
+          document.documentElement.style.setProperty('--filter-bar-height', `${h}px`);
+        }
+      }
     });
-    observer.observe(nav);
+    if (nav) observer.observe(nav);
+    if (filterBar) observer.observe(filterBar);
     return () => observer.disconnect();
   }, [timeline]);
 
@@ -400,6 +408,7 @@ function AgendaApp() {
         showAgendaBuilder=${showAgendaBuilder}
         builderCount=${builder.selectedCount}
       />
+      <${BreakNotice} bookendEvents=${bookendEvents} />
       ${filters.agendaBuilder ? html`
         <${AgendaBuilderPanel}
           timeSlots=${allTimeSlots}

--- a/assets/js/agenda/components.js
+++ b/assets/js/agenda/components.js
@@ -27,7 +27,7 @@ export function TimeSlotNav({ timeline }) {
           break;
         }
       }
-      if (current) setActiveSlot(current);
+      setActiveSlot(current ?? blocks[0]?.dataset.timeslotId ?? null);
     };
 
     window.addEventListener('scroll', onScroll, { passive: true });

--- a/assets/js/agenda/components.js
+++ b/assets/js/agenda/components.js
@@ -11,31 +11,35 @@ export function TimeSlotNav({ timeline }) {
   const [activeSlot, setActiveSlot] = useState(null);
   const navRef = useRef(null);
 
-  // Observe which time slot is currently in view
+  // Track which time slot is currently in view via scroll position
   useEffect(() => {
-    const headers = document.querySelectorAll('[data-timeslot-id]');
-    if (!headers.length) return;
+    const stickyEls = ['.site-header', '.timeslot-nav', '.filter-bar']
+      .map(s => document.querySelector(s));
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting) {
-            setActiveSlot(entry.target.dataset.timeslotId);
-          }
-        });
-      },
-      { rootMargin: '-120px 0px -60% 0px', threshold: 0 }
-    );
+    const onScroll = () => {
+      const cutoff = stickyEls.reduce((sum, el) => sum + (el?.offsetHeight ?? 0), 16);
+      const blocks = document.querySelectorAll('[data-timeslot-id]');
+      let current = null;
+      for (const el of blocks) {
+        if (el.getBoundingClientRect().top <= cutoff) {
+          current = el.dataset.timeslotId;
+        } else {
+          break;
+        }
+      }
+      if (current) setActiveSlot(current);
+    };
 
-    headers.forEach(el => observer.observe(el));
-    return () => observer.disconnect();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener('scroll', onScroll);
   }, [timeline]);
 
   // Auto-scroll the nav strip horizontally so the active pill is visible
   useEffect(() => {
     if (!activeSlot || !navRef.current) return;
     const strip = navRef.current.querySelector('.timeslot-nav-scroll');
-    const pill = navRef.current.querySelector('.timeslot-pill.active');
+    const pill = navRef.current.querySelector(`[data-slot-id="${CSS.escape(activeSlot)}"]`);
     if (strip && pill) {
       const target = pill.offsetLeft - strip.offsetWidth / 2 + pill.offsetWidth / 2;
       const motion = matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth';
@@ -44,13 +48,10 @@ export function TimeSlotNav({ timeline }) {
   }, [activeSlot]);
 
   function scrollTo(slotId) {
-    const el = document.querySelector(`[data-timeslot-id="${CSS.escape(slotId)}"]`);
-    if (el) {
-      // Measure actual sticky elements instead of hardcoding offset
-      const filterBar = document.querySelector('.filter-bar');
-      const headerOffset = (filterBar?.getBoundingClientRect().bottom ?? 140) + 8;
-      const top = el.getBoundingClientRect().top + window.scrollY - headerOffset;
-      window.scrollTo({ top, behavior: 'smooth' });
+    const header = document.querySelector(`[data-timeslot-id="${CSS.escape(slotId)}"]`);
+    const block = header?.closest('.timeslot-block');
+    if (block) {
+      block.scrollIntoView({ behavior: 'smooth' });
     }
   }
 
@@ -59,18 +60,51 @@ export function TimeSlotNav({ timeline }) {
   return html`
     <nav class="timeslot-nav" ref=${navRef} aria-label="Jump to time slot">
       <div class="timeslot-nav-scroll">
-        ${timeline.map(item => html`
-          <button
-            key=${item.slotId}
-            class="timeslot-pill ${item.type === 'bookend' ? 'pill-bookend' : ''} ${activeSlot === item.slotId ? 'active' : ''}"
-            onClick=${() => scrollTo(item.slotId)}
-            aria-label="Jump to ${item.label}"
-          >
-            ${item.label}
-          </button>
-        `)}
+        ${timeline.map(item => {
+          const isBookend = item.type === 'bookend';
+          if (isBookend && item.data.show_in_nav === false) return null;
+          const clickable = !isBookend || item.data.nav_clickable !== false;
+          const cls = `timeslot-pill${isBookend ? ' pill-bookend' : ''}${clickable && activeSlot === item.slotId ? ' active' : ''}`;
+
+          if (!clickable) {
+            return html`
+              <span key=${item.slotId} data-slot-id=${item.slotId}
+                class=${cls} aria-label=${item.label}>${item.label}</span>
+            `;
+          }
+          return html`
+            <button key=${item.slotId} data-slot-id=${item.slotId}
+              class=${cls} onClick=${() => scrollTo(item.slotId)}
+              aria-label="Jump to ${item.label}">${item.label}</button>
+          `;
+        })}
       </div>
     </nav>
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// BreakNotice — compact banner showing lunch & snack break times
+// ---------------------------------------------------------------------------
+
+const breakIcon = html`<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8h1a4 4 0 0 1 0 8h-1"/><path d="M2 8h16v9a4 4 0 0 1-4 4H6a4 4 0 0 1-4-4V8z"/><line x1="6" y1="1" x2="6" y2="4"/><line x1="10" y1="1" x2="10" y2="4"/><line x1="14" y1="1" x2="14" y2="4"/></svg>`;
+
+export function BreakNotice({ bookendEvents }) {
+  const breaks = bookendEvents.filter(e => e.show_in_break_notice);
+  if (!breaks.length) return null;
+
+  return html`
+    <div class="break-notice">
+      ${breaks.map((b, i) => html`
+        ${i > 0 && html`<span class="break-notice-divider" aria-hidden="true"></span>`}
+        <div class="break-notice-item" key=${b.title}>
+          <span class="break-notice-icon" aria-hidden="true">${breakIcon}</span>
+          <span class="break-notice-title">${b.title}</span>
+          <span class="break-notice-time">${b.time}${b.end_time ? ` – ${b.end_time}` : ''}</span>
+          <span class="break-notice-location">${b.location}</span>
+        </div>
+      `)}
+    </div>
   `;
 }
 
@@ -438,6 +472,7 @@ export function AgendaTimeline({ timeline, unscheduledSessions, speakerMap, room
 
       ${timeline.map((item) => {
         if (item.type === 'bookend') {
+          if (item.data.show_in_body === false) return null;
           return html`
             <div class="timeslot-block" key=${item.slotId}>
               <div class="timeslot-header" data-timeslot-id=${item.slotId}>

--- a/sessions.html
+++ b/sessions.html
@@ -15,32 +15,47 @@ bookend_events:
     description: "Check in, grab your badge, and enjoy breakfast and coffee provided by Dunkin."
     location: "Breezeway (next to parking lot)"
     type: "logistics"
+    show_in_nav: true
+    nav_clickable: true
+    show_in_body: true
   - time: "8:00 AM"
     end_time: "9:15 AM"
     title: "Announcements & Keynote"
     description: "Welcome announcements and keynote presentation."
     location: "J100"
     type: "keynote"
+    show_in_nav: false
+    nav_clickable: false
+    show_in_body: false
   - time: "11:20 AM"
     end_time: "12:15 PM"
     title: "Lunch"
-    description: "Lunch provided by Jason's Deli. Pre-ordered during registration on Eventbrite."
-    cta_label: "Register Here"
-    cta_link: "/attendees/"
+    description: "Lunch provided by Jason's Deli."
     location: "Registration Area"
     type: "logistics"
+    show_in_nav: true
+    nav_clickable: true
+    show_in_body: true
+    show_in_break_notice: true
   - time: "4:30 PM"
     end_time: "5:00 PM"
     title: "Closing Remarks & Raffle"
     description: "Prize raffle and closing remarks. Must be present to win!"
     location: "Main Lobby / Rotunda"
     type: "logistics"
+    show_in_nav: true
+    nav_clickable: true
+    show_in_body: true
   - time: "2:05 PM"
     end_time: "2:30 PM"
     title: "Snack Break"
-    description: "Snacks provided by Dynabyte. Pre-ordered during registration on Eventbrite."
-    location: "Sponsors Area"
+    description: "Snacks provided by Dynabyte."
+    location: "The UP building rotunda"
     type: "social"
+    show_in_nav: true
+    nav_clickable: true
+    show_in_body: true
+    show_in_break_notice: true
   - time: "5:00 PM"
     end_time: "8:00 PM"
     title: "After-Party"
@@ -48,6 +63,9 @@ bookend_events:
     location: "4th Street Bar & Grill, Lake Mary"
     location_link: "https://maps.google.com/?q=4th+Street+Bar+%26+Grill,+Lake+Mary+FL"
     type: "social"
+    show_in_nav: true
+    nav_clickable: true
+    show_in_body: true
 ---
 
 <div id="agenda-app" data-api-id="er10xu03" data-session-threshold="50" data-location-question-id="112742">


### PR DESCRIPTION
## Summary

Rework how bookend events (check-in, lunch, snack break, etc.) are displayed on the sessions page, making their visibility fully data-driven via YAML flags. Fix several scroll tracking and navigation issues with the time slot pills. Add sticky time slot headers. Add CODE Magazine as a swag sponsor.

## Why

The previous bookend rendering was all-or-nothing — every bookend appeared in both the nav pills and the content body with no per-event control. This made it difficult to curate which events are prominent (e.g., show lunch/snack in a notice banner but hide them from the main timeline). The scroll tracking used an IntersectionObserver with a hardcoded offset that drifted as sticky elements stacked up, causing the active pill to highlight the wrong slot and pill clicks to land at the wrong position.

## Key Changes

**Bookend display flags (`sessions.html`)**
- Add `show_in_nav`, `nav_clickable`, `show_in_body`, and `show_in_break_notice` per-event flags
- Update Lunch and Snack Break descriptions and locations

**Agenda JS (`components.js`, `app.js`)**
- TimeSlotNav renders bookend pills as clickable buttons or static labels based on flags
- AgendaTimeline conditionally renders bookend cards based on `show_in_body`
- New `BreakNotice` component shows lunch/snack info driven by `show_in_break_notice`
- Replace IntersectionObserver with scroll listener using measured sticky heights for accurate active pill tracking
- Fix pill click scroll target — use `scrollIntoView` on parent `.timeslot-block` instead of manual offset math on sticky elements
- Track filter bar height via ResizeObserver alongside existing nav height

**Sticky time slot headers (`_agenda.scss`)**
- Time slot headers now pin below the site header, nav, and filter bar while scrolling
- Add `--sticky-offset` CSS custom property to consolidate repeated calc expressions
- Dynamic `scroll-margin-top` on `.timeslot-block` using the same variable

**Sponsor (`sponsors.yml`)**
- Add CODE Magazine as a Swag Sponsor (no tier level, sponsors page only)

## Test Plan

- [ ] Verify bookend pills in nav respect their flags (visible/hidden, clickable/static)
- [ ] Verify bookend cards show/hide in the timeline based on `show_in_body`
- [ ] Verify break notice banner appears with Lunch and Snack Break info
- [ ] Click time slot pills — should scroll to the top of the correct section
- [ ] Scroll through sessions — active pill should track and auto-scroll horizontally
- [ ] Confirm time slot headers stick below the filter bar on mobile and desktop
- [ ] Confirm CODE Magazine appears on the sponsors page with Swag Sponsor badge
- [ ] Confirm CODE Magazine does NOT appear on the home page sponsor grid